### PR TITLE
Fix $username check.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,9 +53,6 @@ do
       if [ "$part_supp" == "y" ]; then
 	echo "Enter Open vSwitch VNM directory: [/var/lib/one/remotes/vnm/ovswitch]"
         read vnm_dir
-        if [ "$username" == "" ]; then
-          username="oneadmin"
-        fi
         sel_err=0
       elif [ "$part_supp" == "n" ]; then
         sel_err=0
@@ -64,6 +61,9 @@ do
       fi
     done
 
+    if [ "$username" == "" ]; then
+      username="oneadmin"
+    fi
     if [ "$group" == "" ]; then
       group="cloud"
     fi


### PR DESCRIPTION
This fixes the place of assigning the default value of $username.

$username's default value 'oneadmin' was assigned only when $part_supp matches 'y'.
If user entered no value at "OpenNebula username" and didn't choose 'y' at "Infiniband partitions support", $username was not assigned the default value, subsequent 'chown' and 'sudo onehost sync' command were failed.