### PR TITLE
Fix start point and end point of removing sriov_ bridge stanza.

### DIFF
--- a/vmm/deploy
+++ b/vmm/deploy
@@ -106,8 +106,8 @@ if [ $sriov_ifaces -gt 0 ]; then
 #Find SR-IOV interfcace in deployment, extract MAC and remove its bridge stanza
       setmac=`cat $domain | grep -A $count sriov | egrep -oh '([a-f0-9]{2}\:*){6}' | sed "1 q;d"`
       line=`cat $domain | grep sriov -n | cut -d ':' -f1 | sed "1 q;d"`
-      line=$[$line - 2]
-      count=$[$count + 3]
+      line=$[$line - 1]
+      count=$[$count + 2]
       while [ $count -gt 0 ]
       do
 	count=$[$count - 1]


### PR DESCRIPTION
This fixes start point and end point of removing sriov_ bridge stanza.

deploy script removed sriov_ bridge stanza overly.
On OpenNebula 4.12.1, oned creates bridge stanza like:

```
(snip)
			<mac address='02:00:c0:a8:01:96'/>
                        <model type='virtio'/>
                </interface>
                <interface type='bridge'>
                        <source bridge='sriov_pt'/>
                        <mac address='02:00:0a:01:80:01'/>
                        <model type='virtio'/>
                </interface>
                <graphics type='vnc' listen='0.0.0.0' port='6001'/>
        </devices>
(snip)
```

```line=$[$line - 2]``` points at previous ```</interface>``` line,
and ```count=$[$count + 3]``` points at next ```<graphics type='vnc' ``` line.
